### PR TITLE
Add sample route guidance feedback

### DIFF
--- a/src/frontend/src/main.jsx
+++ b/src/frontend/src/main.jsx
@@ -11,29 +11,62 @@ const campusLocations = [
   'University Center',
 ];
 
+const sampleRoutes = {
+  'College Park Center|Maverick Activities Center': {
+    eta: '6 minutes',
+    steps: [
+      'Exit College Park Center through the west plaza toward Spaniolo Drive.',
+      'Follow Spaniolo Drive north for one block.',
+      'Turn left on West Nedderman Drive and continue past the College of Business.',
+      'The Maverick Activities Center will be on your right—enter through the main glass doors.',
+    ],
+  },
+};
+
 const App = () => {
   const [startLocation, setStartLocation] = useState('');
   const [destination, setDestination] = useState('');
-  const [feedback, setFeedback] = useState('');
+  const [feedback, setFeedback] = useState(null);
 
   const handleFindRoute = (event) => {
     event.preventDefault();
 
     if (!startLocation || !destination) {
-      setFeedback('Please select both a starting point and destination to continue.');
+      setFeedback({
+        status: 'error',
+        message: 'Please select both a starting point and destination to continue.',
+      });
       return;
     }
 
     if (startLocation === destination) {
-      setFeedback('Choose two different locations to discover a new route.');
+      setFeedback({
+        status: 'error',
+        message: 'Choose two different locations to discover a new route.',
+      });
       return;
     }
 
-    setFeedback(`Your curated route from ${startLocation} to ${destination} is on its way!`);
+    const routeKey = `${startLocation}|${destination}`;
+    const routeDetails = sampleRoutes[routeKey];
+
+    if (routeDetails) {
+      setFeedback({
+        status: 'success',
+        message: `Here is the safest path we recommend from ${startLocation} to ${destination}. Estimated travel time: ${routeDetails.eta}.`,
+        steps: routeDetails.steps,
+      });
+      return;
+    }
+
+    setFeedback({
+      status: 'info',
+      message: `Your curated route from ${startLocation} to ${destination} is on its way!`,
+    });
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-uta-blue via-white to-uta-orange flex items-center justify-center px-4 py-12">
+    <div className="min-h-screen bg-gradient-to-br from-uta-blue via-white to-uta-orange flex flex-col items-center justify-center px-4 py-12">
       <div className="w-full max-w-xl bg-white shadow-2xl rounded-3xl p-10 space-y-8">
         <header className="text-center space-y-4">
           <div className="mx-auto w-20 h-20 rounded-full bg-uta-blue flex items-center justify-center text-white text-3xl font-bold">
@@ -105,13 +138,26 @@ const App = () => {
         </form>
 
         {feedback && (
-          <div className="rounded-2xl border border-uta-blue/20 bg-uta-blue/5 px-4 py-3 text-center text-uta-blue">
-            {feedback}
+          <div
+            className={`rounded-2xl border px-4 py-4 text-uta-blue space-y-3 ${
+              feedback.status === 'error'
+                ? 'border-red-200 bg-red-50 text-red-700'
+                : 'border-uta-blue/20 bg-uta-blue/5'
+            }`}
+          >
+            <p className="text-base font-medium">{feedback.message}</p>
+            {feedback.steps && (
+              <ol className="list-decimal list-inside space-y-1 text-sm text-uta-blue/80">
+                {feedback.steps.map((step, index) => (
+                  <li key={`route-step-${index}`}>{step}</li>
+                ))}
+              </ol>
+            )}
           </div>
         )}
       </div>
 
-      <footer className="text-center text-sm text-gray-400 mt-8">
+      <footer className="mt-8 text-center text-sm text-gray-500">
         Routes and kind messages are coming soon as we build the new MavWalk experience.
       </footer>
     </div>


### PR DESCRIPTION
## Summary
- add sample route data so "Find My Route" returns guidance and friendly messaging
- restructure the main layout to stack the footer under the card and improve feedback styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb91d0e10832cbc8c362af29cadfb